### PR TITLE
darken window title bar (macOS)

### DIFF
--- a/predawn-DEV.sublime-theme
+++ b/predawn-DEV.sublime-theme
@@ -1,4 +1,11 @@
 [
+   {
+    // Title Bar (build 3127+, macOS only)
+    "class": "title_bar",
+    "bg": [30, 30, 30],
+    "fg": [237, 135, 104], //predawn
+    // "fg": [150, 150, 150], //gray
+  },
   {
     // Tabs
     "class": "tabset_control",


### PR DESCRIPTION
uses new `title_bar` class in Sublime Text dev build 3127+ to match window title bar to tab background on macOS 10.10+